### PR TITLE
FIX: /passthrough command error code 502 fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v1.1.4
+
+### Bug Fixes
+
+* Calling to /tcp with POST could result in a 502 error when no characters found in _command_ key and also when there was a timeout waiting for the attached board to respond. Changed error when no characters found in _command_ key to 505.
+
 # v1.1.3
 
 ### Enhancements

--- a/examples/DefaultWifiShield/DefaultWifiShield.ino
+++ b/examples/DefaultWifiShield/DefaultWifiShield.ino
@@ -270,7 +270,7 @@ void passthroughCommand() {
         case PASSTHROUGH_FAIL_TOO_MANY_CHARS:
           return returnFail(501, "Error: Sent more than 31 chars");
         case PASSTHROUGH_FAIL_NO_CHARS:
-          return returnFail(502, "Error: No characters found for key 'command'");
+          return returnFail(505, "Error: No characters found for key 'command'");
         case PASSTHROUGH_FAIL_QUEUE_FILLED:
           return returnFail(503, "Error: Queue is full, please wait 20ms and try again.");
         default:

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_Wifi
-version=1.1.3
+version=1.1.4
 author=AJ Keller <pushtheworldllc@gmail.com>
 maintainer=AJ Keller <pushtheworldllc@gmail.com>
 sentence=The core of the OpenBCI Wifi Shield.


### PR DESCRIPTION
# v1.1.4

### Bug Fixes

* Calling to /tcp with POST could result in a 502 error when no characters found in _command_ key and also when there was a timeout waiting for the attached board to respond. Changed error when no characters found in _command_ key to 505.