### PR TITLE
Dev

### DIFF
--- a/OpenBCI_Wifi_Definitions.h
+++ b/OpenBCI_Wifi_Definitions.h
@@ -9,7 +9,7 @@
 #ifndef __OpenBCI_Wifi_Definitions__
 #define __OpenBCI_Wifi_Definitions__
 
-#define SOFTWARE_VERSION "v2.0.0.0"
+#define SOFTWARE_VERSION "v2.0.0.1"
 
 #define ADS1299_VREF 4.5
 #define MCP3912_VREF 1.2
@@ -17,14 +17,14 @@
 #define ADC_24BIT_MAX_VAL_NANO_VOLT 8388607000000000.0
 #define BYTES_PER_SPI_PACKET 32
 #define BYTES_PER_OBCI_PACKET 33
-#define DEBUG 1
+// #define DEBUG 1
 #define MAX_SRV_CLIENTS 2
 #define BYTES_PER_CHANNEL 3
 #ifdef RAW_TO_JSON
   #define NUM_PACKETS_IN_RING_BUFFER_JSON 28
   #define NUM_PACKETS_IN_RING_BUFFER_RAW 1
 #else
-  #define NUM_PACKETS_IN_RING_BUFFER_RAW 200
+  #define NUM_PACKETS_IN_RING_BUFFER_RAW 175
   #define MAX_PACKETS_PER_SEND_TCP 42
 #endif
 #define WIFI_SPI_MSG_LAST 0x01

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # v2.0.0
 
 ### New Features
@@ -6,18 +5,25 @@
 * UDP support
 * WiFi Direct default support (thanks @jnaulty)
 * New docs (code of conduct, roadmap, contributing, readme)
-* Now visit `http://192.168.4.1/wifi` in your browser to connect wifi shield to a new network
+* When in WiFi direct mode, connect PC to WiFi Shield hotspot, and navigate to `192.168.4.1`
+* Now visit `192.168.4.1/wifi` in your browser to connect wifi shield to a new network
+* To erase your network credentials and use wifi direct, use GUI or go to ip address of wifi shield and go to /wifi/delete
 
 ### Breaking Changes
 
-* No longer doing captive portal by default
+* No longer doing captive portal by default, must join network and go to 192.168.4.1
 
 ### Work In Progress
 
 * MQTT Secure
+* Stability of wifi shield #48
 
-=======
->>>>>>> 5ee1d6f84bb31998753aa78f787f8a443e041474
+## Beta 1
+
+### Bug Fixes
+
+* Can't connect to shield #51
+
 # v1.3.0
 
 At this time, can no longer support both RAW and JSON modes with a single binary file. Need optimized builds. We ended up having two modes that didnt work that well instead of highly optimized builds for the different operating modes.

--- a/examples/WifiShieldMQTTSecure/WifiShieldMQTTSecure.ino
+++ b/examples/WifiShieldMQTTSecure/WifiShieldMQTTSecure.ino
@@ -9,11 +9,12 @@
 #define ESP8266
 #include <time.h>
 #include <ESP8266WiFi.h>
-#include <DNSServer.h>
+// #include <DNSServer.h>
 #include <ESP8266WebServer.h>
 // #include <ESP8266HTTPUpdateServer.h>
 #include "SPISlave.h"
-#include <ESP8266mDNS.h>
+// #include <ESP8266mDNS.h>
+// #include <WiFiManager.h>
 #include <ArduinoJson.h>
 #include <PubSubClient.h>
 #include <WiFiClientSecure.h>
@@ -22,6 +23,8 @@
 
 boolean isWaitingOnResetConfirm;
 boolean ntpOffsetSet;
+boolean tryConnectToMQTT;
+boolean startWifiManager;
 boolean syncingNtp;
 boolean waitingOnNTP;
 boolean wifiReset;
@@ -41,9 +44,6 @@ unsigned long ntpLastTimeSeconds;
 
 WiFiClientSecure espClient;
 PubSubClient clientMQTT(espClient);
-
-const char* ssid = "***";
-const char* password = "***";
 
 ///////////////////////////////////////////
 // Utility functions
@@ -92,24 +92,6 @@ void printWifiStatus() {
   Serial.println(ip);
 }
 
-///////////////////////////////////////////
-// NTP BEGIN
-///////////////////////////////////////////
-
-#ifdef RAW_TO_JSON
-/**
-* Use this to start the sntp time sync
-* @type {Number}
-*/
-void ntpStart() {
-  #ifdef DEBUG
-  Serial.println("Setting time using SNTP");
-  #endif
-  configTime(8 * 3600, 0, "pool.ntp.org", "time.nist.gov");
-}
-#endif
-
-
 ///////////////////////////////////////////////////
 // MQTT
 ///////////////////////////////////////////////////
@@ -140,60 +122,69 @@ boolean noBodyInParam() {
   return server.args() == 0;
 }
 
-void sendHeadersForCORS() {
-  server.sendHeader("Access-Control-Allow-Origin", "*");
-}
+// void sendHeadersForCORS() {
+//   server.sendHeader("Access-Control-Allow-Origin", "*");
+// }
 
-void sendHeadersForOptions() {
-  server.sendHeader("Access-Control-Allow-Origin", "*");
-  server.sendHeader("Access-Control-Allow-Methods", "POST,DELETE,GET,OPTIONS");
-  server.sendHeader("Access-Control-Allow-Headers", "Content-Type");
-  server.send(200, "text/plain", "");
-}
+// void sendHeadersForOptions() {
+//   server.sendHeader("Access-Control-Allow-Origin", "*");
+//   server.sendHeader("Access-Control-Allow-Methods", "POST,DELETE,GET,OPTIONS");
+//   server.sendHeader("Access-Control-Allow-Headers", "Content-Type");
+//   server.send(200, "text/plain", "");
+// }
 
-void serverReturn(int code, String s) {
-  digitalWrite(LED_NOTIFY, LOW);
-  sendHeadersForCORS();
-  server.send(code, "text/plain", s + "\r\n");
-  digitalWrite(LED_NOTIFY, HIGH);
-}
+// void serverReturn(int code, String s) {
+//   digitalWrite(LED_NOTIFY, LOW);
+//   sendHeadersForCORS();
+//   server.send(code, "text/plain", s + "\r\n");
+//   digitalWrite(LED_NOTIFY, HIGH);
+// }
 
-void returnOK(String s) {
-  serverReturn(200, s);
-}
+// void returnOK(String s) {
+//   serverReturn(200, s);
+// }
 
-void returnOK(void) {
-  returnOK("OK");
-}
+// void returnOK(void) {
+//   returnOK("OK");
+// }
 
-/**
-* Used to send a response to the client that the board is not attached.
-*/
-void returnNoSPIMaster() {
-  if (wifi.lastTimeWasPolled < 1) {
-    serverReturn(SPI_NO_MASTER, "Error: No OpenBCI board attached");
-  } else {
-    serverReturn(SPI_TIMEOUT_CLIENT_RESPONSE, "Error: Lost communication with OpenBCI board");
-  }
-}
+// /**
+// * Used to send a response to the client that the board is not attached.
+// */
+// void returnNoSPIMaster() {
+//   if (wifi.lastTimeWasPolled < 1) {
+//     serverReturn(SPI_NO_MASTER, "Error: No OpenBCI board attached");
+//   } else {
+//     serverReturn(SPI_TIMEOUT_CLIENT_RESPONSE, "Error: Lost communication with OpenBCI board");
+//   }
+// }
 
 /**
 * Used to send a response to the client that there is no body in the post request.
 */
-void returnNoBodyInPost() {
-  serverReturn(CLIENT_RESPONSE_NO_BODY_IN_POST, "Error: No body in POST request");
-}
+// void returnNoBodyInPost() {
+//   serverReturn(CLIENT_RESPONSE_NO_BODY_IN_POST, "Error: No body in POST request");
+// }
+
+// void requestWifiManager() {
+//   startWifiManager = true;
+// #ifdef DEBUG
+//   Serial.println("/wifi or /wifi/configure");
+// #endif
+//   sendHeadersForCORS();
+//   server.send(301, "text/html", "<meta http-equiv=\"refresh\" content=\"1; URL='/'\" />");
+// }
 
 /**
 * Return if there is a missing param in the required command
 */
-void returnMissingRequiredParam(const char *err) {
-  serverReturn(CLIENT_RESPONSE_MISSING_REQUIRED_CMD, String(err));
-}
-
-void returnFail(int code, String msg) {
-  serverReturn(code, msg);
-}
+// void returnMissingRequiredParam(const char *err) {
+//   serverReturn(CLIENT_RESPONSE_MISSING_REQUIRED_CMD, String(err));
+// }
+//
+// void returnFail(int code, String msg) {
+//   serverReturn(code, msg);
+// }
 
 bool readRequest(WiFiClient& client) {
   bool currentLineIsBlank = true;
@@ -212,65 +203,64 @@ bool readRequest(WiFiClient& client) {
   return false;
 }
 
-JsonObject& getArgFromArgs(int args) {
-  DynamicJsonBuffer jsonBuffer(JSON_OBJECT_SIZE(args) + (40 * args));
-  JsonObject& root = jsonBuffer.parseObject(server.arg(0));
-  return root;
-}
+// JsonObject& getArgFromArgs(int args) {
+//   DynamicJsonBuffer jsonBuffer(JSON_OBJECT_SIZE(args) + (40 * args));
+//   JsonObject& root = jsonBuffer.parseObject(server.arg(0));
+//   return root;
+// }
 
-JsonObject& getArgFromArgs() {
-  return getArgFromArgs(1);
-}
-
-/**
-* Used to set the latency of the system.
-*/
-void setLatency() {
-  if (noBodyInParam()) return returnNoBodyInPost();
-
-  JsonObject& root = getArgFromArgs();
-
-  if (root.containsKey(JSON_LATENCY)) {
-    wifi.setLatency(root[JSON_LATENCY]);
-    returnOK();
-  } else {
-    returnMissingRequiredParam(JSON_LATENCY);
-  }
-}
+// JsonObject& getArgFromArgs() {
+//   return getArgFromArgs(1);
+// }
 
 /**
 * Used to set the latency of the system.
 */
-void passthroughCommand() {
-  if (noBodyInParam()) return returnNoBodyInPost();
-  if (!wifi.spiHasMaster()) return returnNoSPIMaster();
-  JsonObject& root = getArgFromArgs();
+// void setLatency() {
+//   if (noBodyInParam()) return returnNoBodyInPost();
+//
+//   JsonObject& root = getArgFromArgs();
+//
+//   if (root.containsKey(JSON_LATENCY)) {
+//     wifi.setLatency(root[JSON_LATENCY]);
+//     returnOK();
+//   } else {
+//     returnMissingRequiredParam(JSON_LATENCY);
+//   }
+// }
 
-  #ifdef DEBUG
-  root.printTo(Serial);
-  #endif
-  if (root.containsKey(JSON_COMMAND)) {
-    String cmds = root[JSON_COMMAND];
-    uint8_t retVal = wifi.passthroughCommands(cmds);
-    if (retVal < PASSTHROUGH_PASS) {
-      switch(retVal) {
-        case PASSTHROUGH_FAIL_TOO_MANY_CHARS:
-          return returnFail(501, "Error: Sent more than 31 chars");
-        case PASSTHROUGH_FAIL_NO_CHARS:
-          return returnFail(505, "Error: No characters found for key 'command'");
-        case PASSTHROUGH_FAIL_QUEUE_FILLED:
-          return returnFail(503, "Error: Queue is full, please wait 20ms and try again.");
-        default:
-          return returnFail(504, "Error: Unknown error");
-      }
-    }
-    return;
-  } else {
-    return returnMissingRequiredParam(JSON_COMMAND);
-  }
-}
+/**
+* Used to set the latency of the system.
+*/
+// void passthroughCommand() {
+//   if (noBodyInParam()) return returnNoBodyInPost();
+//   if (!wifi.spiHasMaster()) return returnNoSPIMaster();
+//   JsonObject& root = getArgFromArgs();
+//
+//   #ifdef DEBUG
+//   root.printTo(Serial);
+//   #endif
+//   if (root.containsKey(JSON_COMMAND)) {
+//     String cmds = root[JSON_COMMAND];
+//     uint8_t retVal = wifi.passthroughCommands(cmds);
+//     if (retVal < PASSTHROUGH_PASS) {
+//       switch(retVal) {
+//         case PASSTHROUGH_FAIL_TOO_MANY_CHARS:
+//           return returnFail(501, "Error: Sent more than 31 chars");
+//         case PASSTHROUGH_FAIL_NO_CHARS:
+//           return returnFail(505, "Error: No characters found for key 'command'");
+//         case PASSTHROUGH_FAIL_QUEUE_FILLED:
+//           return returnFail(503, "Error: Queue is full, please wait 20ms and try again.");
+//         default:
+//           return returnFail(504, "Error: Unknown error");
+//       }
+//     }
+//     return;
+//   } else {
+//     return returnMissingRequiredParam(JSON_COMMAND);
+//   }
+// }
 
-#ifdef MQTT
 /**
 * Function called on route `/mqtt` with HTTP_POST with body
 * {"username":"user_name", "password": "you_password", "broker_address": "/your.broker.com"}
@@ -343,38 +333,17 @@ void mqttSetup() {
   Serial.print("Got username: "); Serial.println(mqttUsername);
   Serial.print("Got password: "); Serial.println(mqttPassword);
   Serial.print("Got broker_address: "); Serial.println(mqttBrokerAddress);
-
-  Serial.println("About to try and connect to cloudbrain MQTT server");
 #endif
 
   wifi.setInfoMQTT(mqttBrokerAddress, mqttUsername, mqttPassword, mqttPort);
-  clientMQTT.setServer(wifi.mqttBrokerAddress.c_str(), wifi.mqttPort);
-  boolean connected = false;
-  if (mqttUsername.equals("")) {
+
+  tryConnectToMQTT = true;
 #ifdef DEBUG
-    Serial.println("No auth approach");
+  Serial.println("Will eventually try to connect to mqtt");
 #endif
-    connected = mqttConnect();
-  } else {
-#ifdef DEBUG
-    Serial.println("Auth approach being taken");
-#endif
-    connected = mqttConnect(mqttUsername, mqttPassword);
-  }
-  sendHeadersForCORS();
-  if (connected) {
-    return server.send(200, RETURN_TEXT_JSON, "{\"connected\":true}");
-  } else {
-    return server.send(505, RETURN_TEXT_JSON, "{\"connected\":false}");
-  }
 }
-#endif
 
 void removeWifiAPInfo() {
-  // wifi.curClientResponse = wifi.CLIENT_RESPONSE_OUTPUT_STRING;
-  // wifi.outputString = "Forgetting wifi credentials and rebooting";
-  // wifi.clientWaitingForResponseFullfilled = true;
-
 #ifdef DEBUG
   Serial.println(wifi.outputString);
   Serial.println(ESP.eraseConfig());
@@ -389,6 +358,8 @@ void removeWifiAPInfo() {
 void initializeVariables() {
   isWaitingOnResetConfirm = false;
   ntpOffsetSet = false;
+  tryConnectToMQTT = false;
+  startWifiManager = false;
   syncingNtp = false;
   waitingOnNTP = false;
   wifiReset = false;
@@ -404,15 +375,6 @@ void initializeVariables() {
 }
 
 void setup() {
-
-  WiFi.begin(ssid, password);
-
-  while (WiFi.status() != WL_CONNECTED) {
-    delay(500);
-#ifdef DEBUG
-    Serial.print(".");
-#endif
-  }
 
   initializeVariables();
 
@@ -431,7 +393,6 @@ void setup() {
   digitalWrite(LED_NOTIFY, HIGH);
 
   wifi.ntpStart();
-
 
   SPISlave.onData([](uint8_t * data, size_t len) {
     wifi.spiProcessPacket(data);
@@ -462,23 +423,30 @@ void setup() {
   printWifiStatus();
   Serial.printf("Starting HTTP...\n");
 #endif
-  server.on(HTTP_ROUTE, HTTP_GET, [](){
-    returnOK("Push The World - Please visit https://app.swaggerhub.com/apis/pushtheworld/openbci-wifi-server/1.3.0 for the latest HTTP requests");
-  });
-  server.on(HTTP_ROUTE, HTTP_OPTIONS, sendHeadersForOptions);
 
-  server.on(HTTP_ROUTE_CLOUD, HTTP_GET, [](){
-    digitalWrite(LED_NOTIFY, LOW);
-    sendHeadersForCORS();
-    server.send(200, "text/html", "<!DOCTYPE html> html lang=\"en\"> <head><meta http-equiv=\"refresh\"content=\"0; url=https://app.exocortex.ai\"/><title>Redirecting ...</title></head></html>");
-    digitalWrite(LED_NOTIFY, HIGH);
-  });
-  server.on(HTTP_ROUTE_CLOUD, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on("/index.html", HTTP_GET, [](){
-    returnOK("Push The World - OpenBCI - Wifi bridge - is up and running woo");
-  });
-
+  if (WiFi.SSID().equals("")) {
+    WiFi.mode(WIFI_AP);
+#ifdef DEBUG
+    Serial.println("Turning wifi into access point");
+#endif
+  }
+//   server.on(HTTP_ROUTE, HTTP_GET, [](){
+//     returnOK("Push The World - Please visit https://app.swaggerhub.com/apis/pushtheworld/openbci-wifi-server/1.3.0 for the latest HTTP requests");
+//   });
+//   server.on(HTTP_ROUTE, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_CLOUD, HTTP_GET, [](){
+//     digitalWrite(LED_NOTIFY, LOW);
+//     sendHeadersForCORS();
+//     server.send(200, "text/html", "<!DOCTYPE html> html lang=\"en\"> <head><meta http-equiv=\"refresh\"content=\"0; url=https://app.exocortex.ai\"/><title>Redirecting ...</title></head></html>");
+//     digitalWrite(LED_NOTIFY, HIGH);
+//   });
+//   server.on(HTTP_ROUTE_CLOUD, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on("/index.html", HTTP_GET, [](){
+//     returnOK("Push The World - OpenBCI - Wifi bridge - is up and running woo");
+//   });
+//
   server.on(HTTP_ROUTE_MQTT, HTTP_GET, []() {
     sendHeadersForCORS();
     server.send(200, RETURN_TEXT_JSON, wifi.getInfoMQTT(clientMQTT.connected()));
@@ -486,84 +454,91 @@ void setup() {
   server.on(HTTP_ROUTE_MQTT, HTTP_POST, mqttSetup);
   server.on(HTTP_ROUTE_MQTT, HTTP_OPTIONS, sendHeadersForOptions);
 
-  // These could be helpful...
-  server.on(HTTP_ROUTE_STREAM_START, HTTP_GET, []() {
-    if (!wifi.spiHasMaster()) return returnNoSPIMaster();
-    wifi.passthroughCommands("b");
-    SPISlave.setData(wifi.passthroughBuffer, BYTES_PER_SPI_PACKET);
-    returnOK();
-  });
-  server.on(HTTP_ROUTE_STREAM_START, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_STREAM_STOP, HTTP_GET, []() {
-    if (!wifi.spiHasMaster()) return returnNoSPIMaster();
-    wifi.passthroughCommands("s");
-    SPISlave.setData(wifi.passthroughBuffer, BYTES_PER_SPI_PACKET);
-    returnOK();
-  });
-  server.on(HTTP_ROUTE_STREAM_STOP, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_VERSION, HTTP_GET, [](){
-    returnOK(wifi.getVersion());
-  });
-  server.on(HTTP_ROUTE_VERSION, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_COMMAND, HTTP_POST, passthroughCommand);
-  server.on(HTTP_ROUTE_COMMAND, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_LATENCY, HTTP_GET, [](){
-    returnOK(String(wifi.getLatency()).c_str());
-  });
-  server.on(HTTP_ROUTE_LATENCY, HTTP_POST, setLatency);
-  server.on(HTTP_ROUTE_LATENCY, HTTP_OPTIONS, sendHeadersForOptions);
-
-  if (!MDNS.begin(wifi.getName().c_str())) {
-#ifdef DEBUG
-    Serial.println("Error setting up MDNS responder!");
-#endif
-  } else {
-#ifdef DEBUG
-    Serial.print("Your ESP is called "); Serial.println(wifi.getName());
-#endif
-  }
-
-  server.onNotFound([](){
-    returnFail(404, "Route Not Found");
-  });
-
-  //get heap status, analog input value and all GPIO statuses in one json call
-  server.on(HTTP_ROUTE_ALL, HTTP_GET, [](){
-    sendHeadersForCORS();
-    String output = wifi.getInfoAll();
-    server.setContentLength(output.length());
-    server.send(200, RETURN_TEXT_JSON, output);
-#ifdef DEBUG
-    Serial.println(output);
-#endif
-  });
-  server.on(HTTP_ROUTE_ALL, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_BOARD, HTTP_GET, [](){
-    sendHeadersForCORS();
-    String output = wifi.getInfoBoard();
-    server.setContentLength(output.length());
-    server.send(200, RETURN_TEXT_JSON, output);
-#ifdef DEBUG
-    Serial.println(output);
-#endif
-  });
-  server.on(HTTP_ROUTE_BOARD, HTTP_OPTIONS, sendHeadersForOptions);
-
-  server.on(HTTP_ROUTE_WIFI, HTTP_DELETE, []() {
-    returnOK("Reseting wifi. Please power cycle your board in 10 seconds");
-    wifiReset = true;
-  });
-  server.on(HTTP_ROUTE_WIFI, HTTP_OPTIONS, sendHeadersForOptions);
-
-  // httpUpdater.setup(&server);
+//   // These could be helpful...
+//   server.on(HTTP_ROUTE_STREAM_START, HTTP_GET, []() {
+//     if (!wifi.spiHasMaster()) return returnNoSPIMaster();
+//     wifi.passthroughCommands("b");
+//     SPISlave.setData(wifi.passthroughBuffer, BYTES_PER_SPI_PACKET);
+//     returnOK();
+//   });
+//   server.on(HTTP_ROUTE_STREAM_START, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_STREAM_STOP, HTTP_GET, []() {
+//     if (!wifi.spiHasMaster()) return returnNoSPIMaster();
+//     wifi.passthroughCommands("s");
+//     SPISlave.setData(wifi.passthroughBuffer, BYTES_PER_SPI_PACKET);
+//     returnOK();
+//   });
+//   server.on(HTTP_ROUTE_STREAM_STOP, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_VERSION, HTTP_GET, [](){
+//     returnOK(wifi.getVersion());
+//   });
+//   server.on(HTTP_ROUTE_VERSION, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_COMMAND, HTTP_POST, passthroughCommand);
+//   server.on(HTTP_ROUTE_COMMAND, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_LATENCY, HTTP_GET, [](){
+//     returnOK(String(wifi.getLatency()).c_str());
+//   });
+//   server.on(HTTP_ROUTE_LATENCY, HTTP_POST, setLatency);
+//   server.on(HTTP_ROUTE_LATENCY, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   if (!MDNS.begin(wifi.getName().c_str())) {
+// #ifdef DEBUG
+//     Serial.println("Error setting up MDNS responder!");
+// #endif
+//   } else {
+// #ifdef DEBUG
+//     Serial.print("Your ESP is called "); Serial.println(wifi.getName());
+// #endif
+//   }
+//
+//   server.onNotFound([](){
+//     returnFail(404, "Route Not Found");
+//   });
+//
+//   //get heap status, analog input value and all GPIO statuses in one json call
+//   server.on(HTTP_ROUTE_ALL, HTTP_GET, [](){
+//     sendHeadersForCORS();
+//     String output = wifi.getInfoAll();
+//     server.setContentLength(output.length());
+//     server.send(200, RETURN_TEXT_JSON, output);
+// #ifdef DEBUG
+//     Serial.println(output);
+// #endif
+//   });
+//   server.on(HTTP_ROUTE_ALL, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_BOARD, HTTP_GET, [](){
+//     sendHeadersForCORS();
+//     String output = wifi.getInfoBoard();
+//     server.setContentLength(output.length());
+//     server.send(200, RETURN_TEXT_JSON, output);
+// #ifdef DEBUG
+//     Serial.println(output);
+// #endif
+//   });
+//   server.on(HTTP_ROUTE_BOARD, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_WIFI, HTTP_DELETE, []() {
+//     returnOK("Reseting wifi. Please power cycle your board in 10 seconds");
+//     wifiReset = true;
+//   });
+//   server.on(HTTP_ROUTE_WIFI, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_WIFI_CONFIG, HTTP_GET, requestWifiManager);
+//   server.on(HTTP_ROUTE_WIFI_CONFIG, HTTP_OPTIONS, sendHeadersForOptions);
+//
+//   server.on(HTTP_ROUTE_WIFI_DELETE, HTTP_GET, []() {
+//     returnOK("Reseting wifi. Please power cycle your board in 10 seconds");
+//     wifiReset = true;
+//   });
+//   server.on(HTTP_ROUTE_WIFI_DELETE, HTTP_OPTIONS, sendHeadersForOptions);
 
   server.begin();
-  MDNS.addService("http", "tcp", 80);
+  // MDNS.addService("http", "tcp", 80);
 
 #ifdef DEBUG
   Serial.printf("Ready!\n");
@@ -582,6 +557,13 @@ void setup() {
 
   clientMQTT.setCallback(callbackMQTT);
 
+  wifi.mqttUsername = "****";
+  wifi.mqttPort = 8883;
+  wifi.mqttBrokerAddress = "your.broker.com";
+  wifi.mqttPassword = "****";
+
+  wifi.setOutputProtocol(wifi.OUTPUT_PROTOCOL_MQTT);
+
 #ifdef DEBUG
   Serial.println("Spi has master: " + String(wifi.spiHasMaster() ? "true" : "false"));
 #endif
@@ -594,7 +576,7 @@ void setup() {
 /////////////////////////////////
 /////////////////////////////////
 void loop() {
-  server.handleClient();
+  // server.handleClient();
 
   if (wifiReset) {
     wifiReset = false;
@@ -605,13 +587,15 @@ void loop() {
     delay(1000);
   }
 
-  if (wifi.curOutputProtocol == wifi.OUTPUT_PROTOCOL_MQTT) {
-    if (clientMQTT.connected()) {
-      clientMQTT.loop();
-    } else if (millis() > 5000 + lastMQTTConnectAttempt) {
-      mqttConnect(wifi.mqttUsername, wifi.mqttPassword);
-    }
-  }
+  // if (wifi.curOutputProtocol == wifi.OUTPUT_PROTOCOL_MQTT) {
+  //   if (clientMQTT.connected()) {
+  //     clientMQTT.loop();
+  //   } else if (millis() > 5000 + lastMQTTConnectAttempt) {
+  //     tryConnectToMQTT = true;
+  //     Serial.println("About to try and start mqtt");
+  //     // mqttConnect(wifi.mqttUsername, wifi.mqttPassword);
+  //   }
+  // }
 
   if (syncingNtp) {
     unsigned long long curTime = time(nullptr);
@@ -621,12 +605,93 @@ void loop() {
       wifi.setNTPOffset(micros() % MICROS_IN_SECONDS);
       syncingNtp = false;
       ntpOffsetSet = true;
+      tryConnectToMQTT = true;
 
 #ifdef DEBUG
       Serial.print("\nTime set: "); Serial.println(wifi.getNTPOffset());
 #endif
     }
   }
+
+  boolean restartServer = false;
+
+  if (tryConnectToMQTT) {
+    tryConnectToMQTT = false;
+
+#ifdef DEBUG
+    Serial.printf("%d bytes on heap before stopping local server\n", ESP.getFreeHeap());
+#endif
+    // server.stop();
+#ifdef DEBUG
+    Serial.printf("%d bytes on after stopping local server\n", ESP.getFreeHeap());
+#endif
+    clientMQTT.setServer(wifi.mqttBrokerAddress.c_str(), wifi.mqttPort);
+
+    boolean connected = false;
+  //   if (wifi.mqttUsername.equals("")) {
+  // #ifdef DEBUG
+  //     Serial.println("No auth approach");
+  // #endif
+  //     connected = mqttConnect();
+  //   } else {
+  // #ifdef DEBUG
+  //     Serial.printf("Auth approach being taken with %d bytes in heap\n", ESP.getFreeHeap());
+  // #endif
+  //     connected = mqttConnect(wifi.mqttBrokerAddress.c_str(), wifi.mqttPassword.c_str());
+  //   }
+  //
+    // const char *name = "/aj_pushtheworld.us:eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlJURkZPRUZDUVRNNE1EWXlSVFpEUWpCRVJVUXlNekUxTkVNeU5VRTJRVUkxUWtWRk1rWXlNQSJ9.eyJuaWNrbmFtZSI6ImFqIiwibmFtZSI6ImFqQHB1c2h0aGV3b3JsZC51cyIsInBpY3R1cmUiOiJodHRwczovL3MuZ3JhdmF0YXIuY29tL2F2YXRhci84M2U1OGFhNjRmODBkNDU4ZmQ5M2YzOGI0NjQ1MjQwMj9zPTQ4MCZyPXBnJmQ9aHR0cHMlM0ElMkYlMkZjZG4uYXV0aDAuY29tJTJGYXZhdGFycyUyRmFqLnBuZyIsInVwZGF0ZWRfYXQiOiIyMDE3LTExLTIwVDAxOjI2OjU0LjY2M1oiLCJlbWFpbCI6ImFqQHB1c2h0aGV3b3JsZC51cyIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Nsb3VkYnJhaW4uYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDU5ODExOGRiMDM4ZDNiMWZkNjVhODVlYSIsImF1ZCI6ImozSkY3bGlFaXZ6MDlwU0VVeFRiRXBra09CemkzRWpGIiwiaWF0IjoxNTExMTQxMjE0LCJleHAiOjE1MTExNzcyMTR9.I2lMCKhUNMGjuqdZWaRVzC4s26WLWDntUN6Uxjg7g0JSSThkl9-IQ8JX7TTYK5HfWmxDXV-R-SfOCQVym278bptsiQBdkst1ZmbS5JKkRM8kGAOoib1F7UU5sb1uUHViJoF4O0MjETDF2980B71W_K8GjKE8ft5vU3RjpWnS1A9O8OOv1qSVFn6Jxz9P5yPu6IX_JQVLtWTuD3KPp77xuLqy2hOFxLJvrT1JmKr_AXAIPCbh0DAgeZQWwVBpJau78YC3VgK6PLuvzJ5XqJpw1M4BdkI1DXO2VadrBddDRx6CZhiPXYZiLR85Hig-AOlt7eGV5a9fg_Hw7_GO-33T1g";
+    connected = clientMQTT.connect("openbci", wifi.mqttUsername.c_str(), wifi.mqttPassword.c_str());
+
+    // sendHeadersForCORS();
+    if (connected) {
+#ifdef DEBUG
+      Serial.printf("Connected to MQTT with %d bytes on heap\n" , ESP.getFreeHeap());
+#endif
+      // server.send(200, RETURN_TEXT_JSON, "{\"connected\":true}");
+    } else {
+#ifdef DEBUG
+      Serial.printf("Failed to connect to MQTT with %d bytes on heap\n" , ESP.getFreeHeap());
+#endif
+      // server.send(505, RETURN_TEXT_JSON, "{\"connected\":false}");
+    }
+    // restartServer = true;
+  }
+
+//   if (startWifiManager) {
+//     startWifiManager = false;
+// #ifdef DEBUG
+//     Serial.printf("%d bytes on heap before stopping local server\n", ESP.getFreeHeap());
+// #endif
+//     server.stop();
+// #ifdef DEBUG
+//     Serial.printf("%d bytes on after stopping local server\n", ESP.getFreeHeap());
+// #endif
+//
+//     //Local intialization. Once its business is done, there is no need to keep it around
+//     WiFiManager wifiManager;
+//     WiFiManagerParameter custom_text("<p>Powered by Push The World</p>");
+//     wifiManager.addParameter(&custom_text);
+// #ifdef DEBUG
+//     Serial.printf("Start WiFi Config Portal on WiFi Manager with %d bytes on heap\n" , ESP.getFreeHeap());
+// #endif
+//     if (!wifiManager.startConfigPortal(wifi.getName().c_str())) {
+//       Serial.println("failed to connect and hit timeout");
+//       delay(3000);
+//       //reset and try again, or maybe put it to deep sleep
+//       ESP.reset();
+//       delay(5000);
+//     }
+//
+// #ifdef DEBUG
+//     Serial.printf("Stop WiFi Manager with %d bytes on heap\n" , ESP.getFreeHeap());
+// #endif
+//     restartServer = true;
+//   }
+//
+//   if (restartServer) {
+//     server.begin();
+//   }
 
   if (waitingOnNTP && (millis() > 3000 + ntpLastTimeSeconds)) {
     // Test to see if ntp is good
@@ -650,26 +715,26 @@ void loop() {
     wifi.clientWaitingForResponseFullfilled = false;
     switch (wifi.curClientResponse) {
       case wifi.CLIENT_RESPONSE_OUTPUT_STRING:
-        returnOK(wifi.outputString);
+        // returnOK(wifi.outputString);
         wifi.outputString = "";
         break;
       case wifi.CLIENT_RESPONSE_NONE:
       default:
-        returnOK();
+        // returnOK();
         break;
     }
   }
 
   if (wifi.clientWaitingForResponse && (millis() > (wifi.timePassthroughBufferLoaded + 2000))) {
     wifi.clientWaitingForResponse = false;
-    returnFail(502, "Error: timeout getting command response, be sure board is fully connected");
+    // returnFail(502, "Error: timeout getting command response, be sure board is fully connected");
     wifi.outputString = "";
 #ifdef DEBUG
     Serial.println("Failed to get response in 1000ms");
 #endif
   }
 
-  if((clientMQTT.connected() || wifi.curOutputProtocol == wifi.OUTPUT_PROTOCOL_SERIAL) && (micros() > (lastSendToClient + wifi.getLatency()))) {
+  if ((clientMQTT.connected() || wifi.curOutputProtocol == wifi.OUTPUT_PROTOCOL_SERIAL) && (micros() > (lastSendToClient + wifi.getLatency()))) {
     int packetsToSend = wifi.head - wifi.tail;
     if (packetsToSend < 0) {
       packetsToSend = NUM_PACKETS_IN_RING_BUFFER_JSON + packetsToSend; // for wrap around
@@ -701,5 +766,4 @@ void loop() {
       digitalWrite(LED_NOTIFY, HIGH);
     }
   }
-
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_Wifi
-version=1.3.0
+version=2.0.0-beta1
 author=AJ Keller <pushtheworldllc@gmail.com>
 maintainer=AJ Keller <pushtheworldllc@gmail.com>
 sentence=The core of the OpenBCI Wifi Shield.


### PR DESCRIPTION
# v2.0.0

### New Features

* UDP support
* WiFi Direct default support (thanks @jnaulty)
* New docs (code of conduct, roadmap, contributing, readme)
* When in WiFi direct mode, connect PC to WiFi Shield hotspot, and navigate to `192.168.4.1`
* Now visit `192.168.4.1/wifi` in your browser to connect wifi shield to a new network
* To erase your network credentials and use wifi direct, use GUI or go to ip address of wifi shield and go to /wifi/delete

### Breaking Changes

* No longer doing captive portal by default, must join network and go to 192.168.4.1

### Work In Progress

* MQTT Secure
* Stability of wifi shield #48

## Beta 1

### Bug Fixes

* Can't connect to shield #51