### PR TITLE
FIX: buf where access point name was not set till first wifi manager run

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# v2.0.4
+
+### Bug Fixes
+
+* Access point name not set until wifi manager was ran for the first time.
+
 # v2.0.3
 
 ### Enhancements

--- a/examples/DefaultWifiShield/DefaultWifiShield.ino
+++ b/examples/DefaultWifiShield/DefaultWifiShield.ino
@@ -722,6 +722,7 @@ void setup() {
 #endif
 
   if (WiFi.SSID().equals("")) {
+    WiFi.softAP(wifi.getName().c_str());
     WiFi.mode(WIFI_AP);
 #ifdef DEBUG
     Serial.printf("No stored creds, turning wifi into access point with %d bytes on heap\n", ESP.getFreeHeap());

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OpenBCI_Wifi
-version=2.0.3
+version=2.0.4
 author=AJ Keller <pushtheworldllc@gmail.com>
 maintainer=AJ Keller <pushtheworldllc@gmail.com>
 sentence=The core of the OpenBCI Wifi Shield.


### PR DESCRIPTION
# v2.0.4

### Bug Fixes

* Access point name not set until wifi manager was ran for the first time.