### PR TITLE
add linux.env file to source linux-specific build variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,45 +8,45 @@
 #            makeEspArduino Source      #
 #########################################
 # from: https://github.com/plerup/makeEspArduino
-makeEspArduino = $(HOME)/makeEspArduino/makeEspArduino.mk
+makeEspArduino ?= $(HOME)/makeEspArduino/makeEspArduino.mk
 
 #########################################
 #            Arduino Lib                #
 #########################################
-ARDUINO_LIBS = $(HOME)/Documents/Arduino/libraries
+ARDUINO_LIBS ?= $(HOME)/Documents/Arduino/libraries
 
 #########################################
 #            Arduino Sketch             #
 #########################################
-SKETCH = $(ARDUINO_LIBS)/OpenBCI_WIFI/examples/DefaultWifiShield/DefaultWifiShield.ino
+SKETCH ?= $(ARDUINO_LIBS)/OpenBCI_WIFI/examples/DefaultWifiShield/DefaultWifiShield.ino
 
 #########################################
 #            OpenBCI Lib                #
 #########################################
-OPENBCI_WIFI_DIR = $(ARDUINO_LIBS)/OpenBCI_WIFI
-OPENBCI_WIFI_LIB = $(OPENBCI_WIFI_DIR)/src
+OPENBCI_WIFI_DIR ?= $(ARDUINO_LIBS)/OpenBCI_WIFI
+OPENBCI_WIFI_LIB ?= $(OPENBCI_WIFI_DIR)/src
 
 #########################################
 #            ESP8266 Lib                #
 #########################################
-ESP_ROOT = $(HOME)/esp8266
-ESP_LIBS = $(ESP_ROOT)/libraries
+ESP_ROOT ?= $(HOME)/esp8266
+ESP_LIBS ?= $(ESP_ROOT)/libraries
 
 #########################################
 #            Board Info                 #
 #########################################
-HTTP_ADDR=OpenBCI-2114.local
-UPLOAD_PORT = /dev/ttyUSB0
-# BOARD = openbci
-BOARD = huzzah
-FLASH_DEF = 4M1M
-F_CPU = 80000000l
+HTTP_ADDR ?= OpenBCI-2114.local
+UPLOAD_PORT ?= /dev/ttyUSB0
+# BOARD ?= openbci
+BOARD ?= huzzah
+FLASH_DEF ?= 4M1M
+# F_CPU ?= 160000000l
 
 
 #########################################
 #            Include/Exclude Libs       #
 #########################################
-LIBS = $(OPENBCI_WIFI_LIB) \
+LIBS ?= $(OPENBCI_WIFI_LIB) \
        $(ARDUINO_LIBS)/WiFiManager \
        $(ARDUINO_LIBS)/ArduinoJson \
        $(ARDUINO_LIBS)/PubSubClient \
@@ -64,7 +64,7 @@ LIBS = $(OPENBCI_WIFI_LIB) \
        $(ESP_LIBS)/ESP8266HTTPUpdateServer \
        $(ESP_LIBS)/ArduinoOTA
 
-EXCLUDE_DIRS = $(ARDUINO_LIBS)/ArduinoJson/test \
+EXCLUDE_DIRS ?= $(ARDUINO_LIBS)/ArduinoJson/test \
 	       $(ARDUINO_LIBS)/ArduinoJson/third-party \
 	       $(ARDUINO_LIBS)/ArduinoJson/fuzzing \
 	       $(ARDUINO_LIBS)/WebSockets/examples \

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The library we are interested in using is the [`SPISlave`](https://github.com/es
 There are two steps to flashing code. Compiling the codebase, and then flashing it onto the wifi module.
 Makefiles make it a lot easier. Especially if you use [makeEspArduino](https://github.com/plerup/makeEspArduino). Follow the instructions from the project's github.
 
-The `make` command runs the default commands from `makeEspArduino` with OpenBCI_Wifi specific variables provided in the `Makefile`. By default builds the default sketch in the `examples/` directory.
+The `make` command runs the default commands from `makeEspArduino` with OpenBCI_Wifi specific variables provided in the `Makefile`. By default builds the default sketch in the `examples/` directory. (**Note**: Run `source env/linux.env` to override `make` variables for the build.
 
 -   To build *and* flash run:
 

--- a/env/linux.env
+++ b/env/linux.env
@@ -1,0 +1,7 @@
+# Change environment variables for building on linux OS
+
+
+#########################################
+#            Arduino Lib                #
+#########################################
+export ARDUINO_LIBS=${HOME}/Arduino/libraries


### PR DESCRIPTION
runnning `source env/linux.env` will create an `ARDUINO_LIBS` variable that will override the same variable in the `Makefile`.